### PR TITLE
Make components optional

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -43,17 +43,13 @@ suites:
   - name: default
     sudo: true
     run_list:
-    - recipe[paramount]
+    - recipe[test::default]
   - name: cloud
     run_list:
     - recipe[test::cloud]
   - name: email
     run_list:
     - recipe[test::email]
-  - name: host
-    run_list:
-    - recipe[test::system]
-    - recipe[test::security]
   - name: web
     run_list:
     - recipe[test::web]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 0.1.1
+
 # 0.1.0
 
 Initial release of paramount cookbook

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,5 +9,7 @@
 default['paramount']['domain'] = 'example.com'
 default['paramount']['user'] = 'admin'
 
-default['paramount']['contact'] = 'admin@example.com'
-# default['paramount']['contact'] = "#{node['paramount']['user']}@#{node['paramount']['domain']}"
+default['paramount']['organization'] = 'Example'
+default['paramount']['organization_unit'] = 'Paramount'
+
+default['paramount']['contact'] = node['paramount']['user'] + '@' + node['paramount']['domain'] rescue 'postmaster@example.com'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,4 +12,8 @@ default['paramount']['user'] = 'admin'
 default['paramount']['organization'] = 'Example'
 default['paramount']['organization_unit'] = 'Paramount'
 
-default['paramount']['contact'] = node['paramount']['user'] + '@' + node['paramount']['domain'] rescue 'postmaster@example.com'
+default['paramount']['contact'] = begin
+                                    node['paramount']['user'] + '@' + node['paramount']['domain']
+                                  rescue
+                                    'postmaster@example.com'
+                                  end

--- a/recipes/_cloud.rb
+++ b/recipes/_cloud.rb
@@ -6,13 +6,15 @@
 # License:: Apache License, Version 2.0
 #
 
+include_recipe 'paramount::default'
+
 ssl_certificate 'owncloud-cert' do
   namespace 'owncloud'
 end
 
 # include_recipe 'owncloud'
-# wallabag
-# plex
-# znc
+# include_recipe 'wallabag'
+# include_recipe 'plex'
+# include_recipe 'znc'
 
 include_recipe 'paramount::prosody'

--- a/recipes/_email.rb
+++ b/recipes/_email.rb
@@ -6,6 +6,8 @@
 # License:: Apache License, Version 2.0
 #
 
+include_recipe 'paramount::default'
+
 include_recipe 'openssl::upgrade'
 Chef::Recipe.send(:include, OpenSSLCookbook::RandomPassword)
 node.default['paramount']['encfs_passwd'] = random_password(length: 50, mode: :base64, encoding: 'ASCII')
@@ -41,4 +43,5 @@ include_recipe 'paramount::dkim'
 
 include_recipe 'dspam'
 
+# TODO : optionally include if `paramount::_web` is in run_list
 # include_recipe 'paramount::roundcube'

--- a/recipes/_security.rb
+++ b/recipes/_security.rb
@@ -28,9 +28,9 @@ directory '/etc/httpd/ssl' do
   recursive true
 end
 
-openssl_x509 '/etc/httpd/ssl/unemployable.pem' do
-  common_name 'unemployable.me'
-  org 'Mirwin'
-  org_unit 'Unemployable'
+openssl_x509 "/etc/httpd/ssl/#{node['paramount']['domain']}.pem" do
+  common_name node['paramount']['domain']
+  org node['paramount']['organization']
+  org_unit node['paramount']['organization_unit']
   country 'US'
 end

--- a/recipes/_web.rb
+++ b/recipes/_web.rb
@@ -6,18 +6,12 @@
 # License:: Apache License, Version 2.0
 #
 
+include_recipe 'paramount::default'
+
 include_recipe 'nginx'
 
 service 'nginx' do
   action %i(enable start)
 end
 
-openssl_x509 '/etc/httpd/ssl/unemployable.me.pem' do
-  common_name 'unemployable.me'
-  org 'Miriwn'
-  org_unit 'Unemployable'
-  country 'US'
-end
-
-# instapaper/pocket clone
-include_recipe 'paramount::wallabag'
+# include_recipe 'paramount::wallabag'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,7 @@
 
 include_recipe 'paramount::_security'
 include_recipe 'paramount::_system'
-include_recipe 'paramount::_email'
-include_recipe 'paramount::_web'
-include_recipe 'paramount::_cloud'
+
+# include_recipe 'paramount::_email'
+# include_recipe 'paramount::_web'
+# include_recipe 'paramount::_cloud'

--- a/test/unit/spec/default_spec.rb
+++ b/test/unit/spec/default_spec.rb
@@ -15,9 +15,6 @@ describe 'paramount::default' do
   %w(
     paramount::_security
     paramount::_system
-    paramount::_web
-    paramount::_email
-    paramount::_cloud
   ).each do |cb|
     it "includes recipe: #{cb}" do
       expect(chef_run).to include_recipe(cb)


### PR DESCRIPTION
fixes #15

Each component (`web`, `email`, `cloud`, etc) must be explicitly put into the run_list. This let's users only pick 1 component without bringing in any others.

`::default` should configure an opinionated, secure base system.