### PR TITLE
exempt long blocks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,6 @@ Metrics/LineLength:
 
 Style/FrozenStringLiteralComment:
   EnforcedStyle: when_needed
+
+Metrics/BlockLength:
+  Max: 35


### PR DESCRIPTION
needed for #79 and the new rubocop updated rules.